### PR TITLE
Avoid multiple Handle click outside

### DIFF
--- a/components/CollaborativeRoom.tsx
+++ b/components/CollaborativeRoom.tsx
@@ -42,7 +42,7 @@ const CollaborativeRoom = ({ roomId, roomMetadata, users, currentUserType }: Col
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if(containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      if(inputRef.current && containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setEditing(false);
         updateDocument(roomId, documentTitle);
       }


### PR DESCRIPTION
I see that multiple Update title request are happening while we click on any place other than the input box. I think we need to run the update title api only once, right after we focus out of input field.